### PR TITLE
fix repository link to use

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -25,7 +25,7 @@ Recomendamos abrir el `react boilerplate` usando una herramienta de aprovisionam
 Este es el repositorio que necesitas abrir o clonar:
 
 ```
-https://github.com/4GeeksAcademy/react-hello
+https://github.com/4GeeksAcademy/react-hello-webapp
 ```
 
 **👉 Por favor sigue estos pasos** [cómo comenzar un proyecto de codificación](https://4geeks.com/es/lesson/como-comenzar-un-proyecto-de-codificacion).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We recommend opening the `react boilerplate` using a provisioning tool like [Cod
 This is the repository you need to open or clone:
 
 ```
-https://github.com/4GeeksAcademy/react-hello
+https://github.com/4GeeksAcademy/react-hello-webapp
 ```
 
 **👉 Please follow these steps on** [how to start a coding project](https://4geeks.com/lesson/how-to-start-a-project).


### PR DESCRIPTION
Correction of the readme, the link that must be cloned to make the project is the one of react-hello-webapp before there was the one of react-hello